### PR TITLE
Remove the update for the modified course

### DIFF
--- a/packages/server/src/core.rs
+++ b/packages/server/src/core.rs
@@ -162,7 +162,6 @@ pub fn set_type_and_add_credits(
     sum_credits: &mut f32,
 ) -> bool {
     course_status.set_type(bank_name);
-    course_status.modified = false; // finished handle this course
     if course_status.passed() {
         *sum_credits += course_status.course.credit;
         true


### PR DESCRIPTION
It's a potential bug.
If the user updates a course, triggers the core function, and then triggers it again the modification won't be saved.
Thus, If a user modified a course it should stays modified.